### PR TITLE
[FIX] update ripple lib to 0.10.0 (RT-2956)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "dependencies": {
-    "ripple-lib": "^0.9.2",
+    "ripple-lib": "~0.10.0",
     "superagent": "^0.21.0",
     "async": "^0.9.0",
     "extend": "^2.0.0"


### PR DESCRIPTION
old ripple lib has old sjcl, which does not initialize itself
on internet explorer