### PR TITLE
Return key in login object for manual relogin using id and key

### DIFF
--- a/src/vaultclient.js
+++ b/src/vaultclient.js
@@ -207,7 +207,8 @@ VaultClient.prototype.login = function(username, password, device_id, callback) 
         verified  : authInfo.emailVerified, //DEPRECIATE
         emailVerified    : authInfo.emailVerified,
         profileVerified  : authInfo.profile_verified,
-        identityVerified : authInfo.identity_verified
+        identityVerified : authInfo.identity_verified,
+	key : keys.crypt
       });
     });
   };


### PR DESCRIPTION
This allows us to store the id and key and use it to relogin in a different session/object rather than requiring on it being cached in the this.infos object.