### PR TITLE
[FIX] check for status code

### DIFF
--- a/src/rippletxt.js
+++ b/src/rippletxt.js
@@ -38,7 +38,7 @@ RippleTxt.get = function(domain, fn) {
     console.log(url);
     
     request.get(url, function(err, resp) {
-      if (err || !resp.text) {
+      if (err || resp.statusCode != 200 || !resp.text) {
         return nextUrl(++i);
       }
 


### PR DESCRIPTION
check for status code, not only text content
when retrieving ripple.txt
(because errors such 503 returns text content, so
do not try to parse it)