### PR TITLE
[TASK] Require ssl for ripple.txt requests

### DIFF
--- a/src/rippletxt.js
+++ b/src/rippletxt.js
@@ -8,10 +8,7 @@ var RippleTxt = {
 RippleTxt.urlTemplates = [
   'https://{{domain}}/ripple.txt',
   'https://www.{{domain}}/ripple.txt',
-  'https://ripple.{{domain}}/ripple.txt',
-  'http://{{domain}}/ripple.txt',
-  'http://www.{{domain}}/ripple.txt',
-  'http://ripple.{{domain}}/ripple.txt'
+  'https://ripple.{{domain}}/ripple.txt'
 ];
 
 /**


### PR DESCRIPTION
This could be a breaking change if this is currently used to retrieve from domains without https.